### PR TITLE
Fix bulleted list for diffs to HTTP 1.1

### DIFF
--- a/faq/index.md
+++ b/faq/index.md
@@ -76,11 +76,12 @@ Throughout the process, the core developers of SPDY have been involved in the de
 ### What are the key differences to HTTP/1.x?
 
 At a high level, HTTP/2:
-  * is binary, instead of textual
-  * is fully multiplexed, instead of ordered and blocking
-  * can therefore use one connection for parallelism
-  * uses header compression to reduce overhead
-  * allows servers to "push" responses proactively into client caches
+
+* is binary, instead of textual
+* is fully multiplexed, instead of ordered and blocking
+* can therefore use one connection for parallelism
+* uses header compression to reduce overhead
+* allows servers to "push" responses proactively into client caches
 
 ### Why is HTTP/2 binary?
 


### PR DESCRIPTION
Current formatting on http://http2.github.io/faq/ -

![current](https://cloud.githubusercontent.com/assets/4592/3142450/7544c326-e9bf-11e3-9dde-1e40248d2366.png)

This should fix that.
