### PR TITLE
Some editorial fixes and enhancements

### DIFF
--- a/faq/index.md
+++ b/faq/index.md
@@ -230,15 +230,15 @@ If the negotiation mechanism introduced by HTTP/2 works well, it should be possi
 
 ### Why the rules around Continuation on HEADERS frames?
 
-Continuation exists since a single value (e.g. SETCOOKIE) could exceed 16k, which means it couldn't fit into a single frame. It was decided that the least error-prone way to deal with this was to require that all of the headers data come in back-to-back frames, which made decoding and buffer management easier. 
+Continuation exists since a single value (e.g. Set-Cookie) could exceed 16KiB - 1, which means it couldn't fit into a single frame. It was decided that the least error-prone way to deal with this was to require that all of the headers data come in back-to-back frames, which made decoding and buffer management easier. 
 
 ### What is the minimum or maximum HPACK state size?
 
-The receiver always controls the amount of memory used in HPACK, and can set it to zero at a minimum, with a maximum related to the maximum representable integer in a SETTINGS frame, currently 2^32.
+The receiver always controls the amount of memory used in HPACK, and can set it to zero at a minimum, with a maximum related to the maximum representable integer in a SETTINGS frame, currently 2^32 - 1.
 
-### How can I avoid keeping state?
+### How can I avoid keeping HPACK state?
 
-Send a SETTINGS frame setting state size to zero, then RST all streams until a SETTINGS frame with the ACK bit set has been received.
+Send a SETTINGS frame setting state size (SETTINGS_HEADER_TABLE_SIZE) to zero, then RST all streams until a SETTINGS frame with the ACK bit set has been received.
 
 ### Why is there a single compression/flow-control context? 
 


### PR DESCRIPTION
As you can see, this is just editorial fixes and enhancements.
For "How can I avoid keeping state?" section, I think it refers to HPACK state, so I added it to the section title and in the paragraph, I added SETTINGS_HEADER_TABLE_SIZE as a settings name for the reference.
